### PR TITLE
fix(kdtree): change dimension until cluster splittable, modulo n.dim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,11 @@ Types of changes
 - `Removed` for now removed features.
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
+
+## [0.1.1]
+
+- `Fixed` KDTree doesn't stop splitting along 1 dimension
+
+## [0.1.0]
+
+- `Added` First public version released

--- a/pkg/sigo/kdtree.go
+++ b/pkg/sigo/kdtree.go
@@ -118,6 +118,8 @@ func (n *node) build() {
 			lower, upper, valide = n.split()
 			if !valide {
 				n.incRot()
+			} else {
+				break
 			}
 		}
 

--- a/pkg/sigo/kdtree.go
+++ b/pkg/sigo/kdtree.go
@@ -98,6 +98,10 @@ func (n *node) add(r Record) {
 	n.cluster = append(n.cluster, r)
 }
 
+func (n *node) incRot() {
+	n.rot = (n.rot + 1) % n.tree.dim
+}
+
 func (n *node) build() {
 	if n.isValid() && len(n.cluster) >= 2*n.tree.k {
 		if n == n.tree.root {
@@ -105,7 +109,18 @@ func (n *node) build() {
 		}
 
 		// rollback to simple node
-		lower, upper, valide := n.split()
+		var (
+			lower, upper node
+			valide       bool
+		)
+
+		for i := 1; i <= n.tree.dim; i++ {
+			lower, upper, valide = n.split()
+			if !valide {
+				n.incRot()
+			}
+		}
+
 		if !valide {
 			return
 		}


### PR DESCRIPTION
Based on issue: https://github.com/CGI-FR/SIGO/issues/18

